### PR TITLE
Fetch cnpj data with opencnpj

### DIFF
--- a/src/models/nfe.py
+++ b/src/models/nfe.py
@@ -19,10 +19,9 @@ class Nfe:
     ipi: Decimal
     others: Decimal
     isSimple: bool
-    isSimei: bool
     items: List[NFEItem]
 
-    def __init__(self, key:str, ie:str, number:str, series:str, emitter_name:str, emitter_cnpj:str, emission_date:str, emitter_uf:str, freight:Decimal, insurance:Decimal, others:Decimal, filename:str, isSimple:bool, isSimei:bool, items:List[NFEItem], ipi:Decimal):
+    def __init__(self, key:str, ie:str, number:str, series:str, emitter_name:str, emitter_cnpj:str, emission_date:str, emitter_uf:str, freight:Decimal, insurance:Decimal, others:Decimal, filename:str, isSimple:bool, items:List[NFEItem], ipi:Decimal):
         self.emitter_name = emitter_name
         self.emitter_cnpj = emitter_cnpj
         self.ie = ie
@@ -38,7 +37,6 @@ class Nfe:
         self.ipi = ipi
         self.others = others
         self.isSimple = isSimple
-        self.isSimei = isSimei
 
         if len(emitter_cnpj) != 14:
             raise ValueError("CNPJ deve ter 14 caracteres.")

--- a/src/services/fetch_handler.py
+++ b/src/services/fetch_handler.py
@@ -3,7 +3,7 @@ import requests
 class FetchHandler:
 
     @staticmethod
-    def fetch_cnpj_data(cnpj:str):
+    def fetch_cnpj_data_on_cnpja(cnpj:str):
         url = f"https://open.cnpja.com/office/{cnpj}"
         response = requests.get(url)
 
@@ -16,5 +16,21 @@ class FetchHandler:
             except Exception:
                 message = response.text  # fallback caso não seja JSON
 
-            print(f'ERROR - Failed fetch by CNPJ [CNPJ: {cnpj}, statusCode: {response.status_code}, message: {message}].')
+            print(f'ERROR - Failed fetch by CNPJ with CnpJá [CNPJ: {cnpj}, statusCode: {response.status_code}, message: {message}].')
+            return None
+    
+    def fetch_cnpj_data_on_open_cnpj(cnpj:str):
+        url = f"https://api.opencnpj.org/{cnpj}"
+        response = requests.get(url)
+
+        if response.status_code == 200:
+            return response.json()
+        else:
+            try:
+                error_data = response.json()
+                message = error_data.get("message")
+            except Exception:
+                message = response.text  # fallback caso não seja JSON
+
+            print(f'ERROR - Failed fetch by CNPJ with OpenCNPJ [CNPJ: {cnpj}, statusCode: {response.status_code}, message: {message}].')
             return None

--- a/src/services/xml_processor.py
+++ b/src/services/xml_processor.py
@@ -66,7 +66,6 @@ class XMLProcessor:
                 filename=filename,
                 items=items_data,
                 isSimple=is_simples_optant,
-                isSimei=False,
                 freight=safe_decimal_converter(v_freight),
                 ipi=safe_decimal_converter(v_ipi),
                 insurance=safe_decimal_converter(v_insurance),

--- a/src/services/xml_processor.py
+++ b/src/services/xml_processor.py
@@ -52,7 +52,7 @@ class XMLProcessor:
                 item_data:NFEItem = XMLProcessor._extract_item_data(item)
                 items_data.append(item_data)
 
-            is_simples_optant, is_simei_optant = XMLProcessor.get_simple_and_simei(emitter_cnpj)
+            is_simples_optant = XMLProcessor.is_simple_optant(emitter_cnpj)
 
             nfe: Nfe = Nfe(
                 ie=ie,
@@ -66,7 +66,7 @@ class XMLProcessor:
                 filename=filename,
                 items=items_data,
                 isSimple=is_simples_optant,
-                isSimei=is_simei_optant,
+                isSimei=False,
                 freight=safe_decimal_converter(v_freight),
                 ipi=safe_decimal_converter(v_ipi),
                 insurance=safe_decimal_converter(v_insurance),
@@ -197,13 +197,10 @@ class XMLProcessor:
 
                         return mva_values.original
 
-    def get_simple_and_simei(cnpj: str):
-        fetch_data = FetchHandler.fetch_cnpj_data(cnpj)
+    def is_simple_optant(cnpj: str):
+        response_data = FetchHandler.fetch_cnpj_data_on_open_cnpj(cnpj)
 
-        if not fetch_data:
-            return None, None
+        if not response_data:
+            return None
 
-        is_simples_optant = fetch_data['company']['simples']['optant']
-        is_simei_optant = fetch_data['company']['simei']['optant']
-
-        return is_simples_optant or None, is_simei_optant or None
+        return response_data.get("opcao_simples") == "S"


### PR DESCRIPTION
A API pública do CnpJá tem um limite de 5 requisições/minuto por IP. Visto que notas podemos ter mais consultas em uma única execução, optei por alterar a API utilizada para consultar os dados do CNPJ.

Buscando eu encontrei a OpenCNPJ, nela, podemos fazer 50 requisições/segundo, por IP, resolvendo nosso problema de rate limit.

Foi feita também a remoção do SIMEI, ele só existia porque a API anterior retornava ele, não era utilizado.